### PR TITLE
Build against multiple ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,12 +11,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby: [2.5, 2.6, 2.7, head]
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: bundle install
     - name: Run tests


### PR DESCRIPTION
Running the tests against multiple ruby versions affords us certainty
that we can run on most versions of Ruby that are thrown at us by
whatever OS beneath.

closes #6