### PR TITLE
Improve CI pipeline w/ naming & caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,16 @@ jobs:
       with:
         ruby-version: 2.5
 
+    - name: Recreate Ruby Bundler cache
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile*') }}
+        restore-keys: |
+          ${{ runner.os }}-bundler-
 
     - name: Install dependencies
-      run: bundle install
+      run: bundle install --path ./vendor/bundle
 
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:
@@ -7,17 +7,22 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-
+  build:
+    name: "Build & Test"
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5
+
+
     - name: Install dependencies
       run: bundle install
+
     - name: Run tests
       run: bundle exec rspec


### PR DESCRIPTION
This PR should further improve the CI/CD pipeline, by adding the following:

* more descriptive names for the actual pipeline jobs. They are shown in the UI and should give more insight on what job may have failed in future PRs
* caching `bundler` dependency artifacts saves a bit on the setup time