### PR TITLE
Downgrade simplecov to support SonarCloud analysis

### DIFF
--- a/buchungsstreber.gemspec
+++ b/buchungsstreber.gemspec
@@ -38,6 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.1'
-  spec.add_development_dependency 'simplecov', '~> 0.19.0'
+  # Don't update simplecov dependency, since SonarQube can currently not parse
+  # the changed output format, that was introduced in simplecov-0.18.x
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
 end

--- a/buchungsstreber.gemspec
+++ b/buchungsstreber.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.1'
-  # Don't update simplecov dependency, since SonarQube can currently not parse
-  # the changed output format, that was introduced in simplecov-0.18.x
+  # WARNING: Don't update simplecov dependency, since SonarQube can currently
+  # not parse the changed output format, that was introduced in 0.18.x
   spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
 end


### PR DESCRIPTION
Simplecov changed it's own output format starting with version 0.18.x.
This new format is currently incompatible with SonarQube/SonarCloud
analysis. This commits reverts back to 0.17.x and adds a warning comment
on the dependency.

Fixes #5 