### PR TITLE
Fix: SimpleCov errors out in 0.17.x because of missing option

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -37,15 +37,22 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+      - name: Run rubocop
+        run: ./bin/rubocop_changes
+        continue-on-error: true
+
+      - name: Run rubocop
+        run: ./bin/simplecov_18_17 coverage/.resultset.json > coverage/.resultset17.json
+
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
             -Dsonar.organization=synyx
             -Dsonar.projectKey=com.github.synyx:buchungsstreber
-            -Dsonar.ruby.coverage.reportPaths=coverage/.resultset.json
-            -Dsonar.sources=bin/,lib/
-            -Dsonar.tests=spec/
+            -Dsonar.ruby.coverage.reportPaths=/github/workspace/coverage/.resultset17.json
+            -Dsonar.sources=/github/workspace/bin/,/github/workspace/lib/
+            -Dsonar.tests=/github/workspace/spec/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,3 @@ jobs:
 
     - name: Run tests
       run: bundle exec rspec
-
-    - name: Run rubocop
-      run: ./bin/rubocop_changes
-      continue-on-error: true

--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,6 @@
 SimpleCov.command_name "buchungsstreber"
 SimpleCov.root(__dir__)
 
-SimpleCov.enable_for_subprocesses false
-
 SimpleCov.configure do
   filters.clear
   load_profile 'bundler_filter'

--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,8 @@
 SimpleCov.command_name "buchungsstreber"
 SimpleCov.root(__dir__)
 
+SimpleCov.enable_for_subprocesses false
+
 SimpleCov.configure do
   filters.clear
   load_profile 'bundler_filter'

--- a/bin/simplecov_18_17
+++ b/bin/simplecov_18_17
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+coverage = JSON.parse(File.read(ARGV[0]))
+$stderr.puts [ENV['HOME'], ENV['PWD'], File.expand_path(ARGV[0])]
+
+coverage17 = coverage.inject({}) do |out, (name, app)|
+  app2 = app['coverage'].inject({}) do |memo, (file, inner)|
+    file = file.gsub(%r{#{ENV['PWD']}}, '/github/workspace')
+    memo[file] = inner['lines']
+    memo
+  end
+  out[name] = {
+      'coverage' => app2,
+      'timestamp' => app['timestamp'],
+  }
+  out
+end
+
+puts JSON.dump(coverage17)

--- a/buchungsstreber.gemspec
+++ b/buchungsstreber.gemspec
@@ -38,8 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.1'
-  # WARNING: Don't update simplecov dependency, since SonarQube can currently
-  # not parse the changed output format, that was introduced in 0.18.x
-  spec.add_development_dependency 'simplecov', '~> 0.17.0'
+  spec.add_development_dependency 'simplecov', '~> 0.19.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
 end


### PR DESCRIPTION
Missed that in the last PR, because I was under the assumption that
SonarCloud was simply not reporting any coverage because there was no
code change. Figures that again `coverage/.resultset.json` wasn't
generated, because of using an non-existant SimpleCov configuration
property, that still existed in 0.19.x.

We can simply ignore that special subprocess handling, since our CLI
specs are actually running in-process.
