### PR TITLE
Buchen aggregate

### DIFF
--- a/lib/buchungsstreber/cli/app.rb
+++ b/lib/buchungsstreber/cli/app.rb
@@ -95,7 +95,7 @@ module Buchungsstreber
       def buchen(date = nil)
         date = parse_date(date)
         context = Buchungsstreber::Context.new(options[:file])
-        entries = options[:entries] || context.entries[:entries]
+        entries = options[:entries] || Aggregator.aggregate(context.entries[:entries])
 
         puts style(_('Buche'), :bold)
         entries.select { |e| date.nil? || date == e[:date] }.each do |entry|

--- a/spec/aggregator_spec.rb
+++ b/spec/aggregator_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe Aggregator, '#aggregate' do
       expect(aggregated_entries.length).to eq(2)
     end
   end
+
+  context 'clock aggregation' do
+    it 'does aggregate' do
+      t = lambda do |start, done|
+        diff_in_s = (Time.parse(done) - Time.parse(start)).to_f
+        diff_in_s.to_f / 60 / 60
+      end
+      a = normal_entry.merge(time: t.call('9:30', '11:15'))
+      b = normal_entry.merge(time: t.call('13:15', '15:00'))
+      p [a[:time],b[:time]]
+      aggregated_entries = Aggregator.aggregate([a, b])
+      expect(aggregated_entries.length).to eq(1)
+    end
+  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -116,6 +116,26 @@ RSpec.describe 'CLI App', type: :aruba do
       expect(get_times_stub).to have_been_requested.at_least_once
       expect(add_time_stub).to have_been_requested.once
     end
+
+    it 'adds times aggregated to redmine' do
+      today = Date.today
+      validation_stub = stub_request(:get, "https://localhost/issues/8484.json")
+                          .to_return(status: 200, body: JSON.dump(issue8484))
+      user_stub = stub_request(:get, "https://localhost/users/current.json")
+                    .to_return(status: 200, body: JSON.dump(current_user))
+      get_times_stub = stub_request(:get, "https://localhost/time_entries.json?from=#{today}&to=#{today}&user_id=1")
+                         .to_return(status: 200, body: JSON.dump({ 'time_entries' => [] }))
+      add_time_stub = stub_request(:post, "https://localhost/time_entries.json")
+                        .to_return(status: 201)
+
+      run_command_and_stop('buchungsstreber buchen --debug')
+      expect(last_command_started).to have_output(/Buche/)
+
+      expect(validation_stub).to have_been_requested.at_least_once
+      expect(user_stub).to have_been_requested.at_least_once
+      expect(get_times_stub).to have_been_requested.at_least_once
+      expect(add_time_stub).to have_been_requested.once
+    end
   end
 end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'CLI App', type: :aruba do
 
   context 'Configured buchungsstreber' do
     entry = {
-      Date.today => ['0.25   Orga    S8484   Blog']
+      Date.today => ['0.25   Orga    S8484   Blog', '0.25   Orga    S8484   Blog'],
     }
     issue8484 = {
       "issue" => {
@@ -114,7 +114,7 @@ RSpec.describe 'CLI App', type: :aruba do
       expect(validation_stub).to have_been_requested.at_least_once
       expect(user_stub).to have_been_requested.at_least_once
       expect(get_times_stub).to have_been_requested.at_least_once
-      expect(add_time_stub).to have_been_requested.at_least_once
+      expect(add_time_stub).to have_been_requested.once
     end
   end
 end


### PR DESCRIPTION
When entering times via the 'buchen' action, the times were not aggregated.  This MR should fix #51 .