### PR TITLE
[yaml_timesheet] Open empty "buchungen" file

### DIFF
--- a/lib/buchungsstreber/parser/yaml_timesheet.rb
+++ b/lib/buchungsstreber/parser/yaml_timesheet.rb
@@ -25,7 +25,9 @@ class Buchungsstreber::YamlTimesheet
     else
       timesheet = YAML.load_file(@file_path, {})
     end
-    throw 'invalid line: file should contain map' unless timesheet.is_a?(Hash)
+    if not timesheet.is_a?(Hash)
+      timesheet = {Date.today => ["0.0"]}
+    end
     result = Buchungsstreber::Entries.new
 
     timesheet.each do |date, entries|


### PR DESCRIPTION
The provided code does not throw an error but opens an empty file.

* closes #100