### PR TITLE
Fix minimum_time calculation for non-default values

### DIFF
--- a/lib/buchungsstreber/parser.rb
+++ b/lib/buchungsstreber/parser.rb
@@ -72,9 +72,9 @@ class Buchungsstreber::TimesheetParser
     end
 
     def minimum_time(time, minimum_time_value)
-      minimum_time = ((time * 60 * 60) / 900).ceil
+      time_intervals = (time / minimum_time_value).ceil
 
-      minimum_time * minimum_time_value
+      time_intervals * minimum_time_value
     end
 
     private

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Buchungsstreber::TimesheetParser do
     minimum_time = 0.25
     expect { described_class.new('../CHANGELOG.md', {}, minimum_time) }.to raise_error(/file extension/)
   end
+
+  context 'minimum_time' do
+    subject {
+      Object.new.extend(Buchungsstreber::TimesheetParser::Base)
+    }
+    it 'rounds up to the minimum time interval' do
+      minimum_time = 0.5
+      expect(subject.minimum_time(0.75, minimum_time)).to eq(1.0)
+    end
+    it 'does not change full intervals' do
+      minimum_time = 0.5
+      expect(subject.minimum_time(1.5, minimum_time)).to eq(1.5)
+    end
+    it 'handles weird minimal time intervals' do
+      minimum_time = 0.123
+      expect(subject.minimum_time(0.1, minimum_time)).to eq(0.123)
+    end
+  end
 end
 
 class MockParser


### PR DESCRIPTION
Time intervals are now rounded up correctly to the next `minimum_time` step. 
Previously it was only working for the default value of `0.25` (quarter of an hour), see #124. Or maybe I'm misunderstanding the feature? :)

It not works as I would expect with the _yaml_ format, but I have not tested this with the _buch_ format.